### PR TITLE
Update sha2, ed25519 and curve25519-dalek dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ed25519-dalek"
-version = "2.0.0-pre.0"
+version = "2.0.0-pre.1"
 edition = "2018"
 authors = ["isis lovecruft <isis@patternsinthevoid.net>"]
 readme = "README.md"
@@ -22,14 +22,14 @@ travis-ci = { repository = "dalek-cryptography/ed25519-dalek", branch = "master"
 features = ["nightly", "batch"]
 
 [dependencies]
-curve25519-dalek = { version = "4.0.0-pre.1", default-features = false }
-ed25519 = { version = "1", default-features = false }
+curve25519-dalek = { version = "4.0.0-pre.2", default-features = false }
+ed25519 = { version = "1.3", default-features = false }
 merlin = { version = "3", default-features = false, optional = true }
 rand = { version = "0.8", default-features = false, optional = true }
 rand_core = { version = "0.6", default-features = false, optional = true }
 serde_crate = { package = "serde", version = "1.0", default-features = false, optional = true }
 serde_bytes = { version = "0.11", default-features = false, optional = true }
-sha2 = { version = "0.9", default-features = false }
+sha2 = { version = "0.10", default-features = false }
 zeroize = { version = "1", default-features = false, features = ["zeroize_derive"] }
 
 [dev-dependencies]
@@ -63,3 +63,6 @@ legacy_compatibility = []
 u64_backend = ["curve25519-dalek/u64_backend"]
 u32_backend = ["curve25519-dalek/u32_backend"]
 simd_backend = ["curve25519-dalek/simd_backend"]
+
+[patch.crates-io]
+curve25519-dalek = { git = "https://github.com/mobilecoinfoundation/curve25519-dalek.git", rev = "8791722e0273762552c9a056eaccb7df6baf44d7" }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -19,7 +19,6 @@ use core::fmt::Display;
 #[cfg(feature = "std")]
 use std::error::Error;
 
-
 /// Internal errors.  Most application-level developers will likely not
 /// need to pay any attention to these.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
@@ -39,8 +38,9 @@ pub(crate) enum InternalError {
     VerifyError,
     /// Two arrays did not match in size, making the called signature
     /// verification method impossible.
-    // ArrayLengthError is only constructed when "batch" is enabled
-    #[cfg_attr(not(feature = "batch"), allow(dead_code))]
+    // ArrayLengthError is only constructed in verify_batch, so match its cfg.
+    #[cfg(all(any(feature = "batch", feature = "batch_deterministic"),
+              any(feature = "alloc", feature = "std")))]
     ArrayLengthError{ name_a: &'static str, length_a: usize,
                       name_b: &'static str, length_b: usize,
                       name_c: &'static str, length_c: usize, },
@@ -59,6 +59,8 @@ impl Display for InternalError {
                 => write!(f, "{} must be {} bytes in length", n, l),
             InternalError::VerifyError
                 => write!(f, "Verification equation was not satisfied"),
+            #[cfg(all(any(feature = "batch", feature = "batch_deterministic"),
+                      any(feature = "alloc", feature = "std")))]
             InternalError::ArrayLengthError{ name_a: na, length_a: la,
                                              name_b: nb, length_b: lb,
                                              name_c: nc, length_c: lc, }

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -472,24 +472,24 @@ impl ExpandedSecretKey {
         // This is a really fucking stupid bandaid, and the damned scheme is
         // still bleeding from malleability, for fuck's sake.
         h = Sha512::new()
-            .chain(b"SigEd25519 no Ed25519 collisions")
-            .chain(&[1]) // Ed25519ph
-            .chain(&[ctx_len])
-            .chain(ctx)
-            .chain(&self.nonce)
-            .chain(&prehash[..]);
+            .chain_update(b"SigEd25519 no Ed25519 collisions")
+            .chain_update(&[1]) // Ed25519ph
+            .chain_update(&[ctx_len])
+            .chain_update(ctx)
+            .chain_update(&self.nonce)
+            .chain_update(&prehash[..]);
 
         r = Scalar::from_hash(h);
         R = (&r * &constants::ED25519_BASEPOINT_TABLE).compress();
 
         h = Sha512::new()
-            .chain(b"SigEd25519 no Ed25519 collisions")
-            .chain(&[1]) // Ed25519ph
-            .chain(&[ctx_len])
-            .chain(ctx)
-            .chain(R.as_bytes())
-            .chain(public_key.as_bytes())
-            .chain(&prehash[..]);
+            .chain_update(b"SigEd25519 no Ed25519 collisions")
+            .chain_update(&[1]) // Ed25519ph
+            .chain_update(&[ctx_len])
+            .chain_update(ctx)
+            .chain_update(R.as_bytes())
+            .chain_update(public_key.as_bytes())
+            .chain_update(&prehash[..]);
 
         k = Scalar::from_hash(h);
         s = &(&k * &self.key) + &r;

--- a/tests/ed25519.rs
+++ b/tests/ed25519.rs
@@ -29,7 +29,6 @@ use sha2::Sha512;
 #[cfg(test)]
 mod vectors {
     use curve25519_dalek::{edwards::EdwardsPoint, scalar::Scalar};
-    use ed25519::signature::Signature as _;
     use sha2::{digest::Digest, Sha512};
     use std::convert::TryFrom;
 
@@ -124,9 +123,9 @@ mod vectors {
 
     fn compute_hram(message: &[u8], pub_key: &EdwardsPoint, signature_r: &EdwardsPoint) -> Scalar {
         let k_bytes = Sha512::default()
-            .chain(&signature_r.compress().as_bytes())
-            .chain(&pub_key.compress().as_bytes()[..])
-            .chain(&message);
+            .chain_update(&signature_r.compress().as_bytes())
+            .chain_update(&pub_key.compress().as_bytes()[..])
+            .chain_update(&message);
         let mut k_output = [0u8; 64];
         k_output.copy_from_slice(k_bytes.finalize().as_slice());
         Scalar::from_bytes_mod_order_wide(&k_output)


### PR DESCRIPTION
Updates `sha2`, `ed25519`, `curve25519-dalek` dependencies to latest crates.
Temporarily patched `curve25519-dalek` pending https://github.com/mobilecoinfoundation/curve25519-dalek/pull/2

Also fixes a warning in `tests/ed25519`.

Supports https://github.com/mobilecoinfoundation/mobilecoin/issues/1326